### PR TITLE
Add scores and team pages

### DIFF
--- a/src/api/nhl.ts
+++ b/src/api/nhl.ts
@@ -26,6 +26,7 @@ export async function fetchStandings(): Promise<DivisionStandings[]> {
       // Map the record into our Team structure
       const team: Team = {
         name: record.teamName.default,
+        abbr: record.teamAbbrev?.default || '',
         wins: record.wins,
         losses: record.losses,
         otl: record.otLosses,
@@ -57,6 +58,63 @@ export async function fetchStandings(): Promise<DivisionStandings[]> {
     return divisions;
   } catch (error) {
     console.error('Error fetching NHL standings:', error);
+    throw error;
+  }
+}
+
+export async function fetchScores(): Promise<any[]> {
+  const today = new Date().toISOString().slice(0, 10);
+  const baseUrl = `https://api-web.nhle.com/v1/scoreboard/${today}`;
+  const url = Platform.OS === 'web'
+    ? `https://cors-anywhere.herokuapp.com/${baseUrl}`
+    : baseUrl;
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Error fetching scores: ${response.statusText}`);
+    }
+    const data = await response.json();
+    const games = data.gamesByDate?.find((d: any) => d.date === today)?.games || [];
+    return games;
+  } catch (error) {
+    console.error('Error fetching NHL scores:', error);
+    throw error;
+  }
+}
+
+export async function fetchTeamSchedule(team: string): Promise<any[]> {
+  const baseUrl = `https://api-web.nhle.com/v1/club-schedule-season/${team}/now`;
+  const url = Platform.OS === 'web'
+    ? `https://cors-anywhere.herokuapp.com/${baseUrl}`
+    : baseUrl;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Error fetching schedule: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return data.games || [];
+  } catch (error) {
+    console.error('Error fetching team schedule:', error);
+    throw error;
+  }
+}
+
+export async function fetchTeamRoster(team: string): Promise<any> {
+  const season = '20242025';
+  const baseUrl = `https://api-web.nhle.com/v1/roster/${team}/${season}`;
+  const url = Platform.OS === 'web'
+    ? `https://cors-anywhere.herokuapp.com/${baseUrl}`
+    : baseUrl;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Error fetching roster: ${response.statusText}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching team roster:', error);
     throw error;
   }
 }

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -34,6 +34,14 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <TabBarIcon name="list" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="scores"
+        options={{
+          headerShown:false,
+          title: 'Scores',
+          tabBarIcon: ({ color }) => <TabBarIcon name="table" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/src/app/scores.tsx
+++ b/src/app/scores.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { SafeAreaView, ScrollView, StyleSheet, Text, View, ActivityIndicator } from 'react-native';
+import { fetchScores } from '@/api/nhl';
+
+export default function ScoresScreen() {
+  const [games, setGames] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchScores();
+        setGames(data);
+      } catch (err: any) {
+        setError(err.message || 'Failed to load scores.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <ActivityIndicator style={styles.loading} />
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.errorText}>{error}</Text>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.header}>Today's Games</Text>
+        {games.length === 0 && <Text>No games scheduled.</Text>}
+        {games.map((game) => (
+          <View key={game.id} style={styles.gameRow}>
+            <Text style={styles.gameText}>
+              {game.awayTeam.abbrev} {game.awayTeam.score} @ {game.homeTeam.abbrev} {game.homeTeam.score}
+            </Text>
+          </View>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    padding: 20,
+  },
+  header: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  gameRow: {
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee',
+  },
+  gameText: {
+    fontSize: 16,
+    textAlign: 'center',
+  },
+  loading: {
+    marginTop: 50,
+  },
+  errorText: {
+    marginTop: 50,
+    textAlign: 'center',
+    fontSize: 16,
+    color: 'red',
+  },
+});

--- a/src/app/team/[id].tsx
+++ b/src/app/team/[id].tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import { SafeAreaView, ScrollView, StyleSheet, Text, View, ActivityIndicator } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { fetchTeamRoster, fetchTeamSchedule } from '@/api/nhl';
+
+export default function TeamScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [schedule, setSchedule] = useState<any[]>([]);
+  const [roster, setRoster] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [s, r] = await Promise.all([
+          fetchTeamSchedule(id as string),
+          fetchTeamRoster(id as string),
+        ]);
+        setSchedule(s);
+        setRoster(r);
+      } catch (err: any) {
+        setError(err.message || 'Failed to load team info.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    if (id) load();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <ActivityIndicator style={styles.loading} />
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.errorText}>{error}</Text>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.header}>{id} Roster</Text>
+        {roster && (
+          <View style={styles.section}>
+            {['forwards','defense','goalies'].map((grp) => roster[grp] && roster[grp].map((p: any) => (
+              <Text key={p.id} style={styles.text}>{p.sweaterNumber} - {p.firstName.default} {p.lastName.default}</Text>
+            )))}
+          </View>
+        )}
+        <Text style={styles.header}>Schedule</Text>
+        {schedule.map((g) => (
+          <Text key={g.id} style={styles.text}>
+            {g.gameDate}: {g.awayTeam.abbrev} @ {g.homeTeam.abbrev}
+          </Text>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    padding: 20,
+  },
+  header: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  section: {
+    marginBottom: 20,
+  },
+  text: {
+    fontSize: 16,
+    marginVertical: 2,
+  },
+  loading: {
+    marginTop: 50,
+  },
+  errorText: {
+    marginTop: 50,
+    textAlign: 'center',
+    fontSize: 16,
+    color: 'red',
+  },
+});

--- a/src/components/DivisionBox.tsx
+++ b/src/components/DivisionBox.tsx
@@ -17,9 +17,10 @@ export default function DivisionBox({ divisionName, teams }) {
             <Text style={styles.statsHeaderText}>GB</Text>
           </View>
           {teams.map((team, index) => (
-            <TeamRow 
+            <TeamRow
               key={index}
               name={team.name}
+              abbr={team.abbr}
               wins={team.wins}
               losses={team.losses}
               otl={team.otl}

--- a/src/components/TeamRow.tsx
+++ b/src/components/TeamRow.tsx
@@ -1,9 +1,11 @@
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, View, Text, Pressable } from 'react-native';
+import { Link } from 'expo-router';
 import TeamLogo from './TeamLogo';
 
-export default function TeamRow({ name, wins, losses, otl, points, gb, logo }) {
+export default function TeamRow({ name, abbr, wins, losses, otl, points, gb, logo }) {
     return (
-        <View style={styles.teamRow}>
+        <Link href={`/team/${abbr}`} asChild>
+        <Pressable style={styles.teamRow}>
           <View style={styles.logoContainer}>
           <TeamLogo uri={logo} />
           </View>
@@ -13,7 +15,8 @@ export default function TeamRow({ name, wins, losses, otl, points, gb, logo }) {
           <Text style={styles.statText}>{otl}</Text>
           <Text style={styles.statText}>{points}</Text>
           <Text style={styles.statText}>{gb}</Text>
-        </View>
+        </Pressable>
+        </Link>
       );
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type Team = {
     name: string,
+    abbr: string,
     wins: number,
     losses: number,
     otl: number,


### PR DESCRIPTION
## Summary
- extend `Team` type with `abbr`
- enhance NHL API helpers with scores, schedule, and roster fetchers
- allow navigating to a team page from standings rows
- implement new scores page and team page
- expose new "Scores" tab

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68433abad5048321ab34b3de4a3b4016