### PR TITLE
Add clickable scores leading to game details

### DIFF
--- a/src/api/nhl.ts
+++ b/src/api/nhl.ts
@@ -118,3 +118,21 @@ export async function fetchTeamRoster(team: string): Promise<any> {
     throw error;
   }
 }
+
+export async function fetchGameDetails(gameId: string): Promise<any> {
+  const baseUrl = `https://api-web.nhle.com/v1/gamecenter/${gameId}/landing`;
+  const url =
+    Platform.OS === 'web'
+      ? `https://cors-anywhere.herokuapp.com/${baseUrl}`
+      : baseUrl;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Error fetching game details: ${response.statusText}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.error('Error fetching game details:', error);
+    throw error;
+  }
+}

--- a/src/app/(tabs)/scores.tsx
+++ b/src/app/(tabs)/scores.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { SafeAreaView, ScrollView, StyleSheet, Text, View, ActivityIndicator, Pressable } from 'react-native';
+import { Link } from 'expo-router';
 import TeamLogo from '@/components/TeamLogo';
 import { fetchScores } from '@/api/nhl';
 
@@ -66,22 +67,24 @@ export default function ScoresScreen() {
         <Text style={styles.header}>Games</Text>
         {games.length === 0 && <Text>No games scheduled.</Text>}
         {games.map((game) => (
-          <View key={game.id} style={styles.gameRow}>
-            <View style={styles.teamColumn}>
-              <TeamLogo uri={game.awayTeam.logo} />
-              <Text style={styles.teamText}>{game.awayTeam.abbrev}</Text>
-            </View>
-            <View style={styles.centerColumn}>
-              <Text style={styles.scoreText}>
-                {game.awayTeam.score} - {game.homeTeam.score}
-              </Text>
-              <Text style={styles.timeText}>{formatTime(game.startTimeUTC)}</Text>
-            </View>
-            <View style={styles.teamColumn}>
-              <TeamLogo uri={game.homeTeam.logo} />
-              <Text style={styles.teamText}>{game.homeTeam.abbrev}</Text>
-            </View>
-          </View>
+          <Link key={game.id} href={`/game/${game.id}`} asChild>
+            <Pressable style={styles.gameRow}>
+              <View style={styles.teamColumn}>
+                <TeamLogo uri={game.awayTeam.logo} />
+                <Text style={styles.teamText}>{game.awayTeam.abbrev}</Text>
+              </View>
+              <View style={styles.centerColumn}>
+                <Text style={styles.scoreText}>
+                  {game.awayTeam.score} - {game.homeTeam.score}
+                </Text>
+                <Text style={styles.timeText}>{formatTime(game.startTimeUTC)}</Text>
+              </View>
+              <View style={styles.teamColumn}>
+                <TeamLogo uri={game.homeTeam.logo} />
+                <Text style={styles.teamText}>{game.homeTeam.abbrev}</Text>
+              </View>
+            </Pressable>
+          </Link>
         ))}
       </ScrollView>
     </SafeAreaView>

--- a/src/app/game/[id].tsx
+++ b/src/app/game/[id].tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react';
+import { SafeAreaView, ScrollView, StyleSheet, Text, View, ActivityIndicator } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import TeamLogo from '@/components/TeamLogo';
+import { fetchGameDetails } from '@/api/nhl';
+
+export default function GameScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [game, setGame] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchGameDetails(id as string);
+        setGame(data);
+      } catch (err: any) {
+        setError(err.message || 'Failed to load game details.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    if (id) load();
+  }, [id]);
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <ActivityIndicator style={styles.loading} />
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <Text style={styles.errorText}>{error}</Text>
+      </SafeAreaView>
+    );
+  }
+
+  const scoringPlays: any[] = [];
+  if (game?.summary?.scoring) {
+    game.summary.scoring.forEach((period: any) => {
+      period.goals.forEach((goal: any) => {
+        scoringPlays.push({
+          period: period.periodDescriptor.number,
+          time: goal.timeInPeriod,
+          player: `${goal.firstName.default} ${goal.lastName.default}`,
+          team: goal.teamAbbrev.default,
+        });
+      });
+    });
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.headerRow}>
+          <View style={styles.teamColumn}>
+            <TeamLogo uri={game.awayTeam.logo} />
+            <Text style={styles.teamText}>{game.awayTeam.abbrev}</Text>
+          </View>
+          <Text style={styles.scoreText}>
+            {game.awayTeam.score} - {game.homeTeam.score}
+          </Text>
+          <View style={styles.teamColumn}>
+            <TeamLogo uri={game.homeTeam.logo} />
+            <Text style={styles.teamText}>{game.homeTeam.abbrev}</Text>
+          </View>
+        </View>
+        <Text style={styles.sectionHeader}>Goal Scorers</Text>
+        {scoringPlays.map((goal, index) => (
+          <View key={index} style={styles.goalRow}>
+            <Text style={styles.goalText}>
+              P{goal.period} {goal.time} - {goal.player} ({goal.team})
+            </Text>
+          </View>
+        ))}
+        {scoringPlays.length === 0 && (
+          <Text style={styles.goalText}>No goals yet.</Text>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    padding: 20,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 20,
+  },
+  teamColumn: {
+    alignItems: 'center',
+    marginHorizontal: 12,
+  },
+  teamText: {
+    marginTop: 4,
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  scoreText: {
+    fontSize: 22,
+    fontWeight: 'bold',
+  },
+  sectionHeader: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginTop: 10,
+    marginBottom: 8,
+  },
+  goalRow: {
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#ccc',
+  },
+  goalText: {
+    fontSize: 16,
+  },
+  loading: {
+    marginTop: 50,
+  },
+  errorText: {
+    marginTop: 50,
+    textAlign: 'center',
+    fontSize: 16,
+    color: 'red',
+  },
+});


### PR DESCRIPTION
## Summary
- fetch detailed game info from API
- list goal scorers on new game screen
- make scores list items link to the game page

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684343ff811483218c79d9a924c4c61c