### PR TITLE
Add nested layouts for game and team pages

### DIFF
--- a/src/app/game/_layout.tsx
+++ b/src/app/game/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from 'expo-router';
+
+export default function GameLayout() {
+  return (
+    <Stack>
+      <Stack.Screen name="[id]" options={{ title: 'Game Details' }} />
+    </Stack>
+  );
+}

--- a/src/app/team/_layout.tsx
+++ b/src/app/team/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from 'expo-router';
+
+export default function TeamLayout() {
+  return (
+    <Stack>
+      <Stack.Screen name="[id]" options={{ title: 'Team Info' }} />
+    </Stack>
+  );
+}

--- a/src/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/src/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<Text
+  style={
+    [
+      {
+        "color": "#000",
+      },
+      [
+        undefined,
+        {
+          "fontFamily": "SpaceMono",
+        },
+      ],
+    ]
+  }
+>
+  Snapshot test!
+</Text>
+`;


### PR DESCRIPTION
## Summary
- create stack navigator for game screens
- create stack navigator for team screens
- commit snapshot for StyledText component test

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6843469bb024832197e894aa40f4d83a