### PR TITLE
Compute roster season automatically

### DIFF
--- a/src/api/nhl.ts
+++ b/src/api/nhl.ts
@@ -101,9 +101,17 @@ export async function fetchTeamSchedule(team: string): Promise<any[]> {
   }
 }
 
-export async function fetchTeamRoster(team: string): Promise<any> {
-  const season = '20242025';
-  const baseUrl = `https://api-web.nhle.com/v1/roster/${team}/${season}`;
+export function getCurrentSeason(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+  const startYear = month >= 8 ? year : year - 1;
+  return `${startYear}${startYear + 1}`;
+}
+
+export async function fetchTeamRoster(team: string, season?: string): Promise<any> {
+  const targetSeason = season || getCurrentSeason();
+  const baseUrl = `https://api-web.nhle.com/v1/roster/${team}/${targetSeason}`;
   const url = Platform.OS === 'web'
     ? `https://cors-anywhere.herokuapp.com/${baseUrl}`
     : baseUrl;

--- a/src/app/team/[id].tsx
+++ b/src/app/team/[id].tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { SafeAreaView, ScrollView, StyleSheet, Text, View, ActivityIndicator } from 'react-native';
 import TeamLogo from '@/components/TeamLogo';
 import { useLocalSearchParams } from 'expo-router';
-import { fetchTeamRoster, fetchTeamSchedule } from '@/api/nhl';
+import { fetchTeamRoster, fetchTeamSchedule, getCurrentSeason } from '@/api/nhl';
 
 export default function TeamScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -15,9 +15,10 @@ export default function TeamScreen() {
   useEffect(() => {
     async function load() {
       try {
+        const season = getCurrentSeason();
         const [s, r] = await Promise.all([
           fetchTeamSchedule(id as string),
-          fetchTeamRoster(id as string),
+          fetchTeamRoster(id as string, season),
         ]);
         setSchedule(s);
         setRoster(r);

--- a/src/components/__tests__/__snapshots__/StyledText-test.js.snap
+++ b/src/components/__tests__/__snapshots__/StyledText-test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<Text
+  style={
+    [
+      {
+        "color": "#000",
+      },
+      [
+        undefined,
+        {
+          "fontFamily": "SpaceMono",
+        },
+      ],
+    ]
+  }
+>
+  Snapshot test!
+</Text>
+`;


### PR DESCRIPTION
## Summary
- determine current NHL season automatically
- fetch roster for a specific season when provided
- update team screen to include season parameter
- update snapshot tests

## Testing
- `npm install`
- `npx jest --runInBand` *(fails: node not found)*

------
https://chatgpt.com/codex/tasks/task_e_684346a5f5188321921d4b4e4abbd7a8