### PR TITLE
Add team summary and scorers

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -13,3 +13,12 @@ export type DivisionStandings = {
     divisionName: string,
     teams: Team[],
 }
+
+export type PlayerStat = {
+    id: number,
+    firstName: string,
+    lastName: string,
+    goals: number,
+    assists: number,
+    points: number,
+}


### PR DESCRIPTION
## Summary
- include player scoring data structures
- fetch team record and top scorers from NHL API
- show the summary at the top of each team page

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68434b2b3688832182e8004ff28d8d1c