### PR TITLE
Fix style error on scores tab

### DIFF
--- a/src/components/TeamLogo/TeamLogo.web.tsx
+++ b/src/components/TeamLogo/TeamLogo.web.tsx
@@ -1,17 +1,21 @@
 // components/TeamLogo/TeamLogo.web.tsx
 import React from 'react';
+import { ImageStyle, StyleProp, StyleSheet } from 'react-native';
 
 interface TeamLogoProps {
   uri: string;
-  style?: React.CSSProperties;
+  style?: StyleProp<ImageStyle>;
 }
 
 const TeamLogo = ({ uri, style }: TeamLogoProps) => {
+  // StyleSheet.flatten handles numbers and arrays from StyleSheet.create
+  const flatStyle = StyleSheet.flatten(style) as React.CSSProperties;
+
   return (
     <img
       src={uri}
       alt="Team Logo"
-      style={{ width: 40, height: 40, objectFit: 'contain', ...style }}
+      style={{ width: 40, height: 40, objectFit: 'contain', ...flatStyle }}
     />
   );
 };


### PR DESCRIPTION
## Summary
- ensure web TeamLogo handles `StyleSheet` styles

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434e6705608321a319f3bd19bf31d9